### PR TITLE
Fix date bugs

### DIFF
--- a/src/app/events/event.tsx
+++ b/src/app/events/event.tsx
@@ -1,20 +1,10 @@
 import React from 'react';
+import { formatToLocalTimeZone } from '../utilities/formatToLocalTimeZone';
 
 const Event = ({ location, startTime, endTime, link, title }: { location: string, startTime: string, endTime: string, link: string, title: string }) => {
 
-  const eventStartDate = new Date(startTime);
-  const eventEndDate = new Date(endTime);
-  const options: Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    timeZoneName: 'short'
-  };
-  const formatter = new Intl.DateTimeFormat('en-US', options);
-  const formattedStartDate = formatter.format(eventStartDate);
-  const formattedEndDate = formatter.format(eventEndDate);
+  const formattedStartDate = formatToLocalTimeZone(startTime);
+  const formattedEndDate = formatToLocalTimeZone(endTime);
 
   return (
     <div className="relative flex flex-col my-6 bg-leafy shadow-sm border border-slate-200 rounded-lg p-6">

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -8,7 +8,6 @@ import Footer from '../components/Footer';
 const Events = () => {
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [pageToken, setPageToken] = useState('');
 
   useEffect(() => {
     const fetchData = async () => {
@@ -45,8 +44,8 @@ const Events = () => {
         <div className="max-w-4xl mx-auto">
           { !events.length && <p className="text-center text-md">No upcoming events found</p> }
           { events 
-            && events.map(({ id, location, start, end, htmlLink, summary }: { id: string, location: string, start: { dateTime: string }, end: { dateTime: string }, htmlLink: string, summary: string }) => {
-            return <Event location={location} startTime={start.dateTime} endTime={end.dateTime} link={htmlLink} title={summary} key={id} />})
+            && events.map(({ id, location, start, end, htmlLink, summary }: { id: string, location: string, start: { date: string, dateTime?: string }, end: { date: string, dateTime?: string }, htmlLink: string, summary: string }) => {
+            return <Event location={location} startTime={ start.dateTime || start.date } endTime={ end.dateTime || end.date } link={htmlLink} title={summary} key={id} />})
           }
         </div>
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,8 +101,7 @@ const Home = () => {
               : (
                 <div>
                   <p>No Upcoming Events. </p>
-                  <p>Subscribe to <a href="https://calendar.google.com/calendar/u/0/embed?src=7bd85d9630b008f805dfb8ac4e76bc7475c5a84b03ee80674d56beb9a461fd02@group.calendar.google.com&ctz=America/Los_Angeles&pli=1">our events calendar</a> to stay updated about community events.
-       our calendar for up-to-date information.</p>
+                  <p>Subscribe to <a href="https://calendar.google.com/calendar/u/0/embed?src=7bd85d9630b008f805dfb8ac4e76bc7475c5a84b03ee80674d56beb9a461fd02@group.calendar.google.com&ctz=America/Los_Angeles&pli=1">our events calendar</a> to stay updated about community events.</p>
                 </div>
               )
             }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,24 +5,11 @@ import Link from 'next/link';
 import Footer from './components/Footer';
 import { getUpcomingEvents } from '@/api/calendar';
 import About from './components/About';
+import { formatToLocalTimeZone } from './utilities/formatToLocalTimeZone';
 
 const convertDateToGoogleFormat = (date: string) => {
   return new Date(date).toISOString().replace(/[-/.:]+/g, '');
 };
-
-const formatToLocalTimeZone = (date: string) => {
-  const eventDate = new Date(date);
-  const options: Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    timeZoneName: 'short'
-  };
-  const formatter = new Intl.DateTimeFormat('en-US', options);
-  return formatter.format(eventDate);
-}
 
 const Home = () => {
   const [events, setEvents] = useState([]);
@@ -88,26 +75,37 @@ const Home = () => {
           </section>
           <section className="mx-auto lg:w-3/4">
             <h3 className="section-header">Upcoming Events</h3>
-            <div className="grid grid-cols-1 grid-rows-1 md:grid-cols-3 place-items-center align-center">
-              { events && events.map( ({ end, start, location, summary }, index ) => {
-                const link = `https://calendar.google.com/calendar/r/eventedit?action=TEMPLATE&dates=${convertDateToGoogleFormat(start.dateTime)}/${convertDateToGoogleFormat(end.dateTime)}&text=${summary}&location=${location}&ctz=${start.timeZone}`;
-                return (
-                  <div key={index} className="m-4 block text-neutral-50 rounded-lg bg-dark-violet dark:bg-leafy shadow-secondary-1 dark:bg-surface-dark dark:text-dark-violet text-surface">
-                    <div className="p-6">
-                      <h5 className="mb-6 text-xl font-bold leading-tight">
-                        { summary }
-                      </h5>
-                      <p className="mb-6">
-                        Time: { formatToLocalTimeZone(start.dateTime) } - { formatToLocalTimeZone(end.dateTime) }
-                      </p>
-                      <a href={ link } rel="noreferer noopener" target="_blank" className="bg-leafy dark:bg-dark-violet hover:bg-grass-green text-dark-violet dark:text-leafy font-bold py-2 px-4 rounded">
-                        Add to Calendar
-                      </a>
+            { 
+              events.length ? 
+              (<div className="grid grid-cols-1 grid-rows-1 md:grid-cols-3 place-items-center align-center">
+                { events && events.map( ({ end, start, location, summary, description }: { location: string, start: { date: string, dateTime?: string, timeZone?: string }, end: { date: string, dateTime?: string }, summary: string, description: string }, index: number ) => {
+                  console.log('end', end, start, location, summary)
+                  const link = `https://calendar.google.com/calendar/r/eventedit?action=TEMPLATE&dates=${convertDateToGoogleFormat(start.dateTime || start.date)}/${convertDateToGoogleFormat(end.dateTime || end.date)}&text=${summary}&details=${description}&location=${location}&ctz=${start.timeZone || ''}`;
+                  return (
+                    <div key={index} className="m-4 block text-neutral-50 rounded-lg bg-dark-violet dark:bg-leafy shadow-secondary-1 dark:bg-surface-dark dark:text-dark-violet text-surface">
+                      <div className="p-6">
+                        <h5 className="mb-6 text-xl font-bold leading-tight">
+                          { summary }
+                        </h5>
+                        <p className="mb-6">
+                          Time: { formatToLocalTimeZone(start.dateTime || start.date) } - { formatToLocalTimeZone(end.dateTime || end.date) }
+                        </p>
+                        <a href={ link } rel="noreferer noopener" target="_blank" className="bg-leafy dark:bg-dark-violet hover:bg-grass-green text-dark-violet dark:text-leafy font-bold py-2 px-4 rounded">
+                          Add to Calendar
+                        </a>
+                      </div>
                     </div>
-                  </div>
-                );
-              }) }
-            </div>
+                  );
+                }) }
+              </div>)
+              : (
+                <div>
+                  <p>No Upcoming Events. </p>
+                  <p>Subscribe to <a href="https://calendar.google.com/calendar/u/0/embed?src=7bd85d9630b008f805dfb8ac4e76bc7475c5a84b03ee80674d56beb9a461fd02@group.calendar.google.com&ctz=America/Los_Angeles&pli=1">our events calendar</a> to stay updated about community events.
+       our calendar for up-to-date information.</p>
+                </div>
+              )
+            }
           </section>
         </main>
       </div>

--- a/src/app/utilities/formatToLocalTimeZone.tsx
+++ b/src/app/utilities/formatToLocalTimeZone.tsx
@@ -1,0 +1,13 @@
+export const formatToLocalTimeZone = (date: string) => {
+  const eventDate = new Date(date);
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'short'
+  };
+  const formatter = new Intl.DateTimeFormat('en-US', options);
+  return formatter.format(eventDate);
+}


### PR DESCRIPTION
We were duplicating the formatting of dates in the Home page and Events page - both for event data
- Moved the function to a new file in /utils - formatToLocalTimeZone
- Now Home page and Events page are handling events with the same method

Some events are All Day and don't have a start time or end time
- check for a startTime, if there's no startTime, just use the date and add a time for the user's local time zone
- do checks on home page and events page